### PR TITLE
Update conio.h

### DIFF
--- a/conio.h
+++ b/conio.h
@@ -233,11 +233,11 @@ class __CONIO_H{
       }
       
     int getch(){
-      getch_echo(false);
+      return getch_echo(false);
       }
       
     int getche(){
-      getch_echo(true);
+      return getch_echo(true);
       }
       
     int wherexy(int&x,int&y){


### PR DESCRIPTION
Fixed bad return type error in getch() and getche() when compiling with -fsanitize